### PR TITLE
Fix a bug in controlAC function

### DIFF
--- a/Final2021/code.ino
+++ b/Final2021/code.ino
@@ -47,9 +47,9 @@ float calculateTemperature(int AC) {
 void controlAC(int AC, int fanSpeed, int compressor) {
     if (AC == AC1) {
         analogWrite(Fan1, fanSpeed);
-        analogWrite(Compressor1, compressor);
+        digitalWrite(Compressor1, compressor);
     } else if (AC == AC0) {
-        digitalWrite(Fan2, fanSpeed);
+        analogWrite(Fan2, fanSpeed);
         digitalWrite(Compressor2, compressor);
     }
 }


### PR DESCRIPTION
The function is correct in the readme file but has a bug in the code.ino file
using digitalWrite to enable Compressor1 instead of analogWrite
using analogWrite to control Fan2 speed instead of digitalWrite 
